### PR TITLE
Use which instead of type, which searches $PATH

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -9,7 +9,7 @@ LIBTOOLIZE=libtoolize
 # ==> Caveats
 #  In order to prevent conflicts with Apple's own libtool we have prepended a "g"
 #  so, you have instead: glibtool and glibtoolize.
-type glibtoolize && LIBTOOLIZE=glibtoolize
+which glibtoolize && LIBTOOLIZE=glibtoolize
 
 aclocal -I m4
 $LIBTOOLIZE --copy --force --automake


### PR DESCRIPTION
This way there are no errors shown during bootstrap