### PR TITLE
Do not build contrib and examples by default but require

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = readers examples contrib src
+if WITH_EXTRAS
+	EXTRA_SUBDIRS = examples contrib
+endif
+
+SUBDIRS = readers src $(EXTRA_SUBDIRS)
 
 EXTRA_DIST = bootstrap ChangeLog SCARDGETATTRIB.txt \
 	$(AUX_DIST) \

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,12 @@ AC_ARG_ENABLE(twinserial,
 	[twinserial="${enableval}"], [twinserial=no])
 AM_CONDITIONAL(WITH_TWIN_SERIAL, test "${twinserial}" != "no")
 
+# --enable-extras
+AC_ARG_ENABLE(extras,
+	AS_HELP_STRING([--enable-extras],[also compile examples and contrib]),
+	[extras="${enableval}"], [extras=no])
+AM_CONDITIONAL(WITH_EXTRAS, test "${extras}" != "no")
+
 # --enable-ccidtwindir=DIR
 AC_ARG_ENABLE(ccidtwindir,
 	AS_HELP_STRING([--enable-ccidtwindir=DIR],[directory to install the


### PR DESCRIPTION
Those are probably not needed for most users and pollute the compilation with many warnings.

Require `--enable-extras` for those files.
