### PR TITLE
Don't use the pinpad with the HID generic Smart@Link chip

### DIFF
--- a/src/ccid.c
+++ b/src/ccid.c
@@ -465,6 +465,10 @@ int ccid_open_hack_post(unsigned int reader_index)
 			 */
 			ccid_descriptor->bPINSupport = 0;
 			break;
+		case HID_AVIATOR:
+			/* The chip advertises pinpad but actually doesn't have one */
+			ccid_descriptor->bPINSupport = 0;
+			break;
 
 #if 0
 		/* SCM SCR331-DI contactless */

--- a/src/ccid.c
+++ b/src/ccid.c
@@ -468,6 +468,9 @@ int ccid_open_hack_post(unsigned int reader_index)
 		case HID_AVIATOR:
 			/* The chip advertises pinpad but actually doesn't have one */
 			ccid_descriptor->bPINSupport = 0;
+			/* Firmware uses chaining */
+			ccid_descriptor->dwFeatures &= ~CCID_CLASS_EXCHANGE_MASK;
+			ccid_descriptor->dwFeatures |= CCID_CLASS_EXTENDED_APDU;
 			break;
 
 #if 0

--- a/src/ccid.h
+++ b/src/ccid.h
@@ -210,6 +210,7 @@ typedef struct
 #define MICROCHIP_SEC1100 0x04241104
 #define CHERRY_KC1000SC 0x046A00A1
 #define ElatecTWN4	0x09D80427
+#define HID_AVIATOR	0x076B3A21
 
 #define VENDOR_GEMALTO 0x08E6
 #define GET_VENDOR(readerID) ((readerID >> 16) & 0xFFFF)


### PR DESCRIPTION
This adds the reader description and disables the pinpad, as the device has no pinpad.