### PR TITLE
further issues with O2MICRO OZ776 (0b97:7772)

### DIFF
--- a/src/ccid.h
+++ b/src/ccid.h
@@ -223,6 +223,17 @@ typedef struct
  */
 #define O2MICRO_OZ776_PATCH
 
+/*
+ * The O2Micro OZ776_7772 reader randomly times out in bulk read.
+ * (This is very depending on the smartcard. Even same types of the
+ * same batch behave completely different. Another hardware bug?)
+ * In order to avoid operations to fail, do some resync and retries
+ * during transceiving. This seems to help in all observed cases.
+ *
+ * Observed, tested and fixed on Fujitsu Lifebook E754
+ */
+#define O2MICRO_OZ776_TIMEOUTPATCH	5 /* number of max. resyncs using this reader */
+
 /* Escape sequence codes */
 #define ESC_GEMPC_SET_ISO_MODE		1
 #define ESC_GEMPC_SET_APDU_MODE		2

--- a/src/openct/README
+++ b/src/openct/README
@@ -3,3 +3,7 @@ project <http://www.opensc.org/>
 
 I (Ludovic Rousseau) greatly patched proto-t1.c to add all the needed
 code to reach the quality level requested by the EMV standard.
+
+I (Stephan Baerwolf) slightly modified error-handling in "t1_transceive"
+for "O2 Micro OZ776 CCID Smartcard Reader" devices (0b97:7772).
+(There some "random?" usb timeouts cause operations to fail otherwise.)

--- a/src/openct/proto-t1.c
+++ b/src/openct/proto-t1.c
@@ -161,6 +161,9 @@ int t1_transceive(t1_state_t * t1, unsigned int dad,
 	unsigned char sdata[T1_BUFFER_SIZE], sblk[5];
 	unsigned int slen, retries, resyncs;
 	size_t last_send = 0;
+#ifdef	O2MICRO_OZ776_TIMEOUTPATCH
+	_ccid_descriptor *ccid_descriptor = get_ccid_descriptor(t1->lun);
+#endif
 
 	if (snd_len == 0)
 		return -1;
@@ -174,6 +177,11 @@ int t1_transceive(t1_state_t * t1, unsigned int dad,
 
 	t1->state = SENDING;
 	retries = t1->retries;
+#if	((O2MICRO_OZ776_TIMEOUTPATCH) > 0)
+	if (ccid_descriptor->readerID == OZ776_7772) {
+	  resyncs = (O2MICRO_OZ776_TIMEOUTPATCH);
+	} else
+#endif
 	resyncs = 3;
 
 	/* Initialize send/recv buffer */
@@ -213,6 +221,14 @@ int t1_transceive(t1_state_t * t1, unsigned int dad,
 
 		if (n < 0) {
 			DEBUG_CRITICAL("fatal: transmit/receive failed");
+#ifdef O2MICRO_OZ776_TIMEOUTPATCH
+			if (ccid_descriptor->readerID == OZ776_7772) {
+			  DEBUG_INFO2("patching timeout bug for O2MICRO_OZ776, retries=%u",retries);
+			  if (retries <= 0) {
+			    goto resync;
+			  } else continue;
+			}
+#endif
 			t1->state = DEAD;
 			goto error;
 		}


### PR DESCRIPTION
Hi all.

Recently I was confronted with serious issues regarding the reader within Fujitsu Lifebook E754.
Turns out it is the O2 Micros's OZ776.

Simplified: I was not able to read back some x509 certificates with it. (And other security tools errored while using it.)
(Althought all test passed using an external USB card reader...)
After debugging it more and more became obvious, all disruptions are caused by an LIBUSB_ERROR_TIMEOUT (-7) - the reader simply didn't respond in some cases.

Hereby I want to suggest my patch making the reader fully usable.
In case somebody needs pcscd before-patch- and after-patch logs, please write me, I will make them available then.

BR Stephan
