### PR TITLE
Fix missing openct/README in distribution.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ parse_LDADD = $(LIBUSB_LIBS)
 parse_CFLAGS = $(PCSC_CFLAGS) $(LIBUSB_CFLAGS) -DSIMCLIST_NO_DUMPRESTORE
 
 EXTRA_DIST = Info.plist.src create_Info_plist.pl reader.conf.in \
-	towitoko/COPYING towitoko/README openct/LICENSE \
+	towitoko/COPYING towitoko/README openct/LICENSE openct/README \
 	convert_version.pl 92_pcscd_ccid.rules
 
 # We can't use install-exec-local since we want to overwrite the install


### PR DESCRIPTION
After running "make dist", openct/README is not found in the
distribution. To fix the problem, openct/README is added to EXTRA_DIST
in src/Makefile.am.