### PR TITLE
Add some workarounds to make VMWARE CCID work

### DIFF
--- a/src/ccid.c
+++ b/src/ccid.c
@@ -80,6 +80,15 @@ int ccid_open_hack_pre(unsigned int reader_index)
 			/* The SCM SCL011 reader needs 350 ms to answer */
 			ccid_descriptor->readTimeout = DEFAULT_COM_READ_TIMEOUT * 4;
 			break;
+
+		case VMWARE_CCID:
+			/* This is not an actual reader, it's an emulated reader that
+			 * acts as a proxy to the reader present on the host machine.
+			 * Anounced dwFeatures are wrong, override them here. */
+			ccid_descriptor->dwFeatures = 0x0002047E;
+			/* It also doesn't have any pinpad */
+			ccid_descriptor->bPINSupport = 0;
+			break;
 	}
 
 	/* CCID */

--- a/src/ccid.h
+++ b/src/ccid.h
@@ -213,6 +213,7 @@ typedef struct
 #define ElatecTWN4	0x09D80427
 #define SCM_SCL011 0x04E65293
 #define HID_AVIATOR	0x076B3A21
+#define	VMWARE_CCID	0x0E0F0004
 
 #define VENDOR_GEMALTO 0x08E6
 #define GET_VENDOR(readerID) ((readerID >> 16) & 0xFFFF)


### PR DESCRIPTION
Add some workarounds to make the emulated CCID reader presented by the VMWare hypervisor to the guests, work properly. Tested on a VMWare Fusion guest, running Gentoo linux.