### PR TITLE
Disable USB autosuspend on C3PO LTC31 v1 reader

### DIFF
--- a/src/92_pcscd_ccid.rules
+++ b/src/92_pcscd_ccid.rules
@@ -14,5 +14,8 @@ ATTRS{idVendor}=="0d46", ATTRS{idProduct}=="4081", RUN+="/usr/sbin/Kobil_mIDenti
 # set USB power management to auto.
 ENV{ID_USB_INTERFACES}==":0b0000:", TEST=="power/control", ATTR{power/control}="auto"
 
+# Keep USB autosuspend off for the C3PO LTC31 v1 SmartCard Reader
+ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{idVendor}=="0783", ATTR{idProduct}=="0003", ATTR{power/control}="on"
+
 # All done
 LABEL="pcscd_ccid_rules_end"


### PR DESCRIPTION
The device doesn't seem to work fine when resuming from suspension mode.
By preventing autosuspension the device doesn't fail anymore.

See github issue #36
"USB autosuspend problem: libusb_open returns LIBUSB_ERROR_IO"
https://github.com/LudovicRousseau/CCID/issues/36