### PR TITLE
Create macOS_Sierra10.12

### DIFF
--- a/macOS_Sierra10.12
+++ b/macOS_Sierra10.12
@@ -1,0 +1,1 @@
+.zip file  for sierra 10.12 will not open and states that it is damaged Forced to send to trash. 


### PR DESCRIPTION
.zip file  for sierra 10.12 will not open and states that it is damaged. Forced to send file to trash.