### PR TITLE
Enhancement #68

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1099,6 +1099,14 @@ static int get_end_points(struct libusb_config_descriptor *desc,
 } /* get_end_points */
 
 
+EXTERNAL uint8_t get_ccid_usb_bus_number(int reader_index) {
+	return usbDevice[reader_index].bus_number;
+}
+
+EXTERNAL uint8_t get_ccid_usb_device_address(int reader_index) {
+	return usbDevice[reader_index].device_address;
+}
+
 /*****************************************************************************
  *
  *					get_ccid_usb_interface

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1099,6 +1099,7 @@ static int get_end_points(struct libusb_config_descriptor *desc,
 } /* get_end_points */
 
 
+#if !defined(TWIN_SERIAL)
 EXTERNAL uint8_t get_ccid_usb_bus_number(int reader_index) {
 	return usbDevice[reader_index].bus_number;
 }
@@ -1106,6 +1107,7 @@ EXTERNAL uint8_t get_ccid_usb_bus_number(int reader_index) {
 EXTERNAL uint8_t get_ccid_usb_device_address(int reader_index) {
 	return usbDevice[reader_index].device_address;
 }
+#endif
 
 /*****************************************************************************
  *

--- a/src/ccid_usb.h
+++ b/src/ccid_usb.h
@@ -37,6 +37,9 @@ status_t CloseUSB(unsigned int reader_index);
 
 const unsigned char *get_ccid_device_descriptor(const struct libusb_interface *usb_interface);
 
+uint8_t get_ccid_usb_bus_number(int reader_index);
+uint8_t get_ccid_usb_device_address(int reader_index);
+
 int ControlUSB(int reader_index, int requesttype, int request, int value,
 	unsigned char *bytes, unsigned int size);
 

--- a/src/ccid_usb.h
+++ b/src/ccid_usb.h
@@ -37,8 +37,10 @@ status_t CloseUSB(unsigned int reader_index);
 
 const unsigned char *get_ccid_device_descriptor(const struct libusb_interface *usb_interface);
 
+#if !defined(TWIN_SERIAL)
 uint8_t get_ccid_usb_bus_number(int reader_index);
 uint8_t get_ccid_usb_device_address(int reader_index);
+#endif
 
 int ControlUSB(int reader_index, int requesttype, int request, int value,
 	unsigned char *bytes, unsigned int size);

--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -612,6 +612,7 @@ EXTERNAL RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 			}
 			break;
 
+#if !defined(TWIN_SERIAL)
 		case SCARD_ATTR_CHANNEL_ID:
 			{
 				*Length = sizeof(uint32_t);
@@ -622,6 +623,7 @@ EXTERNAL RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 				}
 			}
 			break;
+#endif
 
 		default:
 			return_value = IFD_ERROR_TAG;

--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -612,6 +612,17 @@ EXTERNAL RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 			}
 			break;
 
+		case SCARD_ATTR_CHANNEL_ID:
+			{
+				*Length = sizeof(uint32_t);
+				if (Value) {
+					uint32_t bus  = get_ccid_usb_bus_number(reader_index);
+					uint32_t addr = get_ccid_usb_device_address(reader_index);
+					*(uint32_t *)Value = ((uint32_t)0x0020 << 16) | bus << 8 | addr;
+				}
+			}
+			break;
+
 		default:
 			return_value = IFD_ERROR_TAG;
 	}


### PR DESCRIPTION
This patch uses new constants in PCSC (when available).
These new constants allow an access to USB parameters:
- bus_number
- device_address
- device_port
- product_id
- vendor_id