### PR TITLE
Added code to allow homebrew dylib during installation.

### DIFF
--- a/MacOSX/configure
+++ b/MacOSX/configure
@@ -47,9 +47,10 @@ LIBUSB_DIR=$(pkg-config --variable=libdir libusb-1.0)
 LIBUSB_ARCHIVE="$LIBUSB_DIR"/libusb-1.0.a
 LIBUSB_CFLAGS=$(pkg-config --cflags --static libusb-1.0)
 LIBUSB_LIBS=$(pkg-config --libs --static libusb-1.0)
+LIBUSB_IS_HOMEBREW=$(which brew 2> /dev/null)
 
-if ls "$LIBUSB_DIR"/libusb-1.0*.dylib 2> /dev/null
-then
+ls -1 "$LIBUSB_DIR"/libusb-1.0*.dylib > /dev/null 2>&1
+if [ "$?" ] && [ ! -f $LIBUSB_IS_HOMEBREW ]; then
 	echo -en $RED
 	echo "*****************************"
 	echo "Dynamic library libusb found in $LIBUSB_DIR"


### PR DESCRIPTION
I have modified the check for the dylib. If the dylib is installed and Homebrew is installed, the check will no longer raise an error. This fix will allow the package to be added to the Hombrew repository. 