### PR TITLE
Use "buffer.h" instead of <openct/buffer.h>

### DIFF
--- a/src/openct/buffer.c
+++ b/src/openct/buffer.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #endif
 
-#include <openct/buffer.h>
+#include "buffer.h"
 
 void
 ct_buf_init(ct_buf_t *bp, void *mem, size_t len)


### PR DESCRIPTION
buffer.c should include buffer.h directly from current directory instead
of including it from system directory.