### PR TITLE
reader-proto-not-supported-fix: change returned value to IFD_NOT_SUPPORTED if reader does not support protocol

### DIFF
--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -736,7 +736,7 @@ EXTERNAL RESPONSECODE IFDHSetProtocolParameters(DWORD Lun, DWORD Protocol,
 	{
 		DEBUG_CRITICAL2("Protocol T=" DWORD_D " not supported by reader",
 			Protocol - SCARD_PROTOCOL_T0);
-		return IFD_ERROR_NOT_SUPPORTED;
+		return IFD_NOT_SUPPORTED;
 	}
 
 	/* Get ATR of the card */


### PR DESCRIPTION
reader-proto-not-supported-fix: change returned value to IFD_NOT_SUPPORTED if reader does not support protocol

Commit 8dda1322 'Fail if the requested protocol is not supported by
reader' was meant to signal to PC/SC daemon that reader does not support
(i.e by means of its CCID descriptor) requested protocol even if card
supports it.

Unfortunately error IFD_ERROR_NOT_SUPPORTED was selected to return on
such case from CCID, which is not used in error handling of PTS in pcscd
daemon - only IFD_PROTOCOL_NOT_SUPPORTED and IFD_NOT_SUPPORTED are
handled there.