### PR TITLE
Fix potential memcpy call with null dest

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1605,7 +1605,7 @@ time_request:
 		DEBUG_CRITICAL2("Nul block expected but got %d bytes", length);
 		return_value = IFD_COMMUNICATION_ERROR;
 	}
-	else
+	else if (length)
 		memcpy(rx_buffer, cmd+10, length);
 
 	/* Extended case?


### PR DESCRIPTION
Add a check into CCID_Receive() in commands.c that skips calling
memcpy() in case the count is zero. This fixes the (theoretical) problem
in case both the count and the dest pointer are zero (such a call can be
made, e.g., from CmdXfrBlockAPDU_extended()) and the compiler uses the
non-null argument requirement to generate some incorrect code.

This potential issue was found by clang-tidy (the "NonNullParamChecker"
diagnostic).