### PR TITLE
Support 4 card slot with Feitian R502 C9

### DIFF
--- a/src/ccid.h
+++ b/src/ccid.h
@@ -240,6 +240,7 @@ typedef struct
 #define IDENTIV_uTrust4701F		0x04E65724
 
 #define VENDOR_GEMALTO 0x08E6
+#define VENDOR_FEITIAN 0x096E
 #define GET_VENDOR(readerID) ((readerID >> 16) & 0xFFFF)
 
 /*

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -464,6 +464,7 @@ again_libusb:
 					 * 0: R502 Contactless Reader (CCID)
 					 * 1: R502 Contact Reader (CCID)
 					 * 2: R502 SAM1 Reader (CCID)
+					 * 3: R502 SAM2 Reader (CCID)
 					 *
 					 * For the HID Omnikey 5422 the interfaces are:
 					 * 0: OMNIKEY 5422CL Smartcard Reader
@@ -474,6 +475,10 @@ again_libusb:
 					if (HID_OMNIKEY_5422 == readerID)
 						/* only 2 interfaces for this device */
 						max_interface_number = 1;
+
+					if (FEITIANR502DUAL == readerID)
+						/*4 interfaces for Feitian R502 reader */
+						max_interface_number = 3;
 				}
 #endif
 				/* is it already opened? */

--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -476,9 +476,9 @@ EXTERNAL RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 						|| (HID_OMNIKEY_5422 == readerID))
 						*Value = 2;
 
-					/* 3 CCID interfaces */
+					/* 4 CCID interfaces */
 					if (FEITIANR502DUAL == readerID)
-						*Value = 3;
+						*Value = 4;
 				}
 #endif
 				DEBUG_INFO2("Reader supports %d slot(s)", *Value);
@@ -1467,7 +1467,10 @@ EXTERNAL RESPONSECODE IFDHControl(DWORD Lun, DWORD dwControlCode,
 				&& (0 == memcmp(TxBuffer, switch_interface, sizeof(switch_interface))))
 				allowed = TRUE;
 		}
-
+		if (VENDOR_FEITIAN == GET_VENDOR(readerID))
+		{
+			allowed = TRUE;
+		}
 		if (!allowed)
 		{
 			DEBUG_INFO1("ifd exchange (Escape command) not allowed");


### PR DESCRIPTION
The R502 C9 has 4 interfaces, which is contact, contactless, 2xSAM,
modify code to support 4 slots.