### PR TITLE
Fix for unsupported commands: GET_CLOCK_FREQUENCIES and improvement of previous fix for GET_DATA_RATES

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -496,15 +496,15 @@ static int ccid_parse_interface_descriptor(libusb_device_handle *handle,
 				int i;
 
 				/* we do not get the expected number of data rates */
-				if ((n != device_descriptor[27]*4) && device_descriptor[27])
+				if ((n != bNumDataRatesSupported*4) && bNumDataRatesSupported)
 				{
 					(void)printf("   Got %d data rates but was expecting %d\n", n/4,
-						device_descriptor[27]);
+						bNumDataRatesSupported);
 
 					/* we got more data than expected */
 #ifndef DISPLAY_EXTRA_VALUES
-					if (n > device_descriptor[27]*4)
-						n = device_descriptor[27]*4;
+					if (n > bNumDataRatesSupported*4)
+						n = bNumDataRatesSupported*4;
 #endif
 				}
 


### PR DESCRIPTION
This pull request aims to fix the case of two commands possibly unsupported by some readers:

GET_CLOCK_FREQUENCIES (bNumClockSupported) - new fix

GET_DATA_RATES (bNumDataRatesSupported) - code style improvement of previous fix

Both fixes seem to be needed at least on the following reader: Bit4Id miniLector AIR NFC v3 (25DD:3403).