### PR TITLE
Use slot variable in ccid_usb.c

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1550,7 +1550,7 @@ static void *Multi_PollingProc(void *p_ext)
 							change = (slot_status & 2) ? "status changed" : "no change";
 
 							DEBUG_COMM3("slot %d status: %d",
-								s + b*4, slot_status);
+								s + slot, slot_status);
 							DEBUG_COMM3("ICC %s, %s", present, change);
 						}
 						slot += 4;


### PR DESCRIPTION
Use the slot variable instead of calculating the number every time.

This also fixes the warning from clang:

ccid_usb.c:1521:11: warning: variable 'slot' set but not used [-Wunused-but-set-variable]