### PR TITLE
Add in the ability to dynamically adjust module path at run-time via system environmental exports

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,9 @@ TOKEN_PARSER = tokenparser.l parser.h \
 	misc.h \
 	strlcpycat.h \
 	simclist.c \
-	simclist.h
+	simclist.h \
+	ccid_env.c \
+	ccid_env.h
 
 if WITHOUT_PCSC
 PROVIDED_BY_PCSC = debug.c

--- a/src/ccid_env.c
+++ b/src/ccid_env.c
@@ -1,0 +1,59 @@
+/*
+    ccid_env.c: Environment management code for CCID
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this library; if not, write to the Free Software Foundation,
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <config.h>
+
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "ccid_env.h"
+
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+# if __GLIBC_PREREQ(2, 17)
+char * secure_getenv (const char *name);
+# endif
+#endif
+
+char * ccid_getenv(const char *name)
+{
+/* Use secure_getenv if we have glibc >= 2.17 */
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+# if __GLIBC_PREREQ(2, 17)
+#  define SECURE_GETENV
+	return secure_getenv(name);
+# endif
+#endif
+
+/* Otherwise, make sure current process is not
+   tainted by uid or gid changes */
+#ifndef SECURE_GETENV
+	if (issetugid())
+		return NULL;
+	return getenv(name);
+#endif
+}

--- a/src/ccid_env.h
+++ b/src/ccid_env.h
@@ -1,0 +1,24 @@
+/*
+    env.c: Environment management code for CCID
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this library; if not, write to the Free Software Foundation,
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef CCID_ENV_H
+#define CCID_ENV_H
+
+char * ccid_getenv(const char *name);
+
+#endif

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -40,6 +40,7 @@
 #include "utils.h"
 #include "parser.h"
 #include "ccid_ifdhandler.h"
+#include "ccid_env.h"
 
 
 /* write timeout
@@ -248,6 +249,7 @@ status_t OpenUSBByName(unsigned int reader_index, /*@null@*/ char *device)
 	int rv;
 	bool claim_failed = false;
 	int return_value = STATUS_SUCCESS;
+	char * hpDirPath;
 
 	DEBUG_COMM3("Reader index: %X, Device: " LOG_STRING, reader_index, device);
 
@@ -311,9 +313,14 @@ status_t OpenUSBByName(unsigned int reader_index, /*@null@*/ char *device)
 		return STATUS_UNSUCCESSFUL;
 	}
 
+	/* Check if path override present in environment */
+	hpDirPath = ccid_getenv("PCSCLITE_HP_DROPDIR");
+	if(!hpDirPath)
+		hpDirPath = PCSCLITE_HP_DROPDIR;
+
 	/* Info.plist full patch filename */
 	(void)snprintf(infofile, sizeof(infofile), "%s/%s/Contents/Info.plist",
-		PCSCLITE_HP_DROPDIR, BUNDLE);
+		hpDirPath, BUNDLE);
 	DEBUG_INFO2("Using: " LOG_STRING, infofile);
 
 	rv = bundleParse(infofile, &plist);

--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -50,6 +50,7 @@
 #include "towitoko/pps.h"
 #include "parser.h"
 #include "strlcpycat.h"
+#include "ccid_env.h"
 
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
@@ -2069,12 +2070,18 @@ void init_driver(void)
 	char *e;
 	int rv;
 	list_t plist, *values;
+	char * hpDirPath;
 
 	DEBUG_INFO1("Driver version: " VERSION);
 
+	/* Check if path override present in environment */
+	hpDirPath = ccid_getenv("PCSCLITE_HP_DROPDIR");
+	if(!hpDirPath)
+		hpDirPath = PCSCLITE_HP_DROPDIR;
+
 	/* Info.plist full patch filename */
 	(void)snprintf(infofile, sizeof(infofile), "%s/%s/Contents/Info.plist",
-		PCSCLITE_HP_DROPDIR, BUNDLE);
+		hpDirPath, BUNDLE);
 
 	rv = bundleParse(infofile, &plist);
 	if (0 == rv)


### PR DESCRIPTION
Add in the ability to dynamically adjust module path at run-time via system environmental exports

Background: While trying to integrate PKCS11+HSM into a build system (Yocto Project), we wanted the build system to be able to use the HSM directly. However, The Yocto Project creates a sandboxed environment for each package which uses CCID during compilation. This means that the CCID modules cannot be found from within these sandboxed directories, as their paths are non-determinable at compile time. OpenSSL appears to use OPENSSL_CONF for this sort of dynamic configuration, so I've followed their lead and incorporated a similar ccid_getenv() method.