### PR TITLE
Simulate ACS WalletMate as multi-slot reader

### DIFF
--- a/src/ccid.h
+++ b/src/ccid.h
@@ -251,6 +251,7 @@ typedef struct
 #define ALCOR_LINK_AK9567		0x2CE39567
 #define ALCOR_LINK_AK9572		0x2CE39573
 #define ALCORMICRO_AU9540		0x058f9540
+#define ACS_WALLETMATE			0x072F226B
 
 #define VENDOR_GEMALTO 0x08E6
 #define GET_VENDOR(readerID) ((readerID >> 16) & 0xFFFF)

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -481,6 +481,7 @@ again_libusb:
 					case HID_OMNIKEY_5422:
 					case ALCOR_LINK_AK9567:
 					case ALCOR_LINK_AK9572:
+					case ACS_WALLETMATE:
 						max_interface_number = 1; /* 2 interfaces */
 						break;
 
@@ -707,6 +708,7 @@ again:
 					|| (HID_OMNIKEY_5422 == readerID)
 					|| (ALCOR_LINK_AK9567 == readerID)
 					|| (ALCOR_LINK_AK9572 == readerID)
+					|| (ACS_WALLETMATE == readerID)
 					|| (FEITIANR502DUAL == readerID))
 				{
 					/* use the next interface for the next "slot" */

--- a/src/ifdhandler.c
+++ b/src/ifdhandler.c
@@ -476,6 +476,7 @@ EXTERNAL RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 						|| (GEMALTOPROXSU == readerID)
 						|| (ALCOR_LINK_AK9567 == readerID)
 						|| (ALCOR_LINK_AK9572 == readerID)
+						|| (ACS_WALLETMATE == readerID)
 						|| (HID_OMNIKEY_5422 == readerID))
 						*Value = 2;
 


### PR DESCRIPTION
This reader has 2 CCID interfaces.