### PR TITLE
Check num_altsetting before dereffing altsetting

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1181,6 +1181,11 @@ const unsigned char *get_ccid_device_descriptor(const struct libusb_interface *u
 	uint8_t last_endpoint;
 #endif
 
+	if (0 == usb_interface->num_altsetting) {
+		/* No interface descriptor available. */
+		return NULL;
+	}
+
 	if (54 == usb_interface->altsetting->extra_length)
 		return usb_interface->altsetting->extra;
 
@@ -1295,6 +1300,10 @@ uint8_t get_ccid_usb_device_address(int reader_index)
 	/* if multiple interfaces use the first one with CCID class type */
 	for (i = *num; i < desc->bNumInterfaces; i++)
 	{
+		if (desc->interface[i].num_altsetting == 0) {
+			/* No interface descriptor available. */
+			continue;
+		}
 		/* CCID Class? */
 		if (desc->interface[i].altsetting->bInterfaceClass == 0xb
 #ifdef ALLOW_PROPRIETARY_CLASS


### PR DESCRIPTION
According to the libusb documentation,
libusb_interface::num_altsetting must be non-negative, hence it's allowed to be zero, in which case dereferencing
libusb_interface::altsetting isn't allowed. Fix the places in the CCID code that do this without proper checks.