### PR TITLE
Add Fujitsu Dual Smartcard Reader D321

### DIFF
--- a/readers/Fujitsu_Smartcard_Reader_D321.txt
+++ b/readers/Fujitsu_Smartcard_Reader_D321.txt
@@ -1,0 +1,99 @@
+Bus 001 Device 004: ID 0bf8:101b Fujitsu Siemens Computers Dual Smartcard Reader D321
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.00
+  bDeviceClass            0
+  bDeviceSubClass         0
+  bDeviceProtocol         0
+  bMaxPacketSize0         8
+  idVendor           0x0bf8 Fujitsu Siemens Computers
+  idProduct          0x101b
+  bcdDevice            1.81
+  iManufacturer           1 FujitsuTechnologySolutions GmbH
+  iProduct                2 Dual Smartcard Reader D321
+  iSerial                 5 OKCM0072012131553329060233456820
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength       0x005d
+    bNumInterfaces          1
+    bConfigurationValue     1
+    iConfiguration          3 CCID
+    bmAttributes         0xa0
+      (Bus Powered)
+      Remote Wakeup
+    MaxPower              250mA
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           3
+      bInterfaceClass        11 Chip/SmartCard
+      bInterfaceSubClass      0
+      bInterfaceProtocol      0
+      iInterface              0
+      ChipCard Interface Descriptor:
+        bLength                54
+        bDescriptorType        33
+        bcdCCID              1.00
+        nMaxSlotIndex           0
+        bVoltageSupport         7  5.0V 3.0V 1.8V
+        dwProtocols             3  T=0 T=1
+        dwDefaultClock       4800
+        dwMaxiumumClock      8000
+        bNumClockSupported      4
+        dwDataRate          10752 bps
+        dwMaxDataRate      412903 bps
+        bNumDataRatesSupp.    106
+        dwMaxIFSD             254
+        dwSyncProtocols  00000007  2-wire 3-wire I2C
+        dwMechanical     00000000
+        dwFeatures       000103B0
+          Auto clock change
+          Auto baud rate change
+          Auto PPS made by CCID
+          CCID can set ICC in clock stop mode
+          NAD value other than 0x00 accepted
+          TPDU level exchange
+        dwMaxCCIDMsgLen       271
+        bClassGetResponse    echo
+        bClassEnvelope       echo
+        wlcdLayout           none
+        bPINSupport             0
+        bMaxCCIDBusySlots       1
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0008  1x 8 bytes
+        bInterval              24
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x84  EP 4 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x05  EP 5 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+Device Status:     0x0000
+  (Bus Powered)
+

--- a/readers/supported_readers.txt
+++ b/readers/supported_readers.txt
@@ -452,6 +452,7 @@
 # FujitsuTechnologySolutions GmbH
 0x0BF8:0x1017:FujitsuTechnologySolutions GmbH SmartCase KB SCR eSIG
 0x0BF8:0x1021:FujitsuTechnologySolutions GmbH Keyboard KB SCR2
+0x0BF8:0x101B:Fujitsu Smartcard Reader D321
 
 # Gemalto
 0x0898:0x0101:Gemalto RF CR5400


### PR DESCRIPTION
Technical data for Fujitsu Dual Smartcard Reader D321 Both Smartcard types:
Smartcard format ID1
Interface to PC USB

Smartcard with contacts:
Card class A, B, C
Protocol T=0, T=1
Interface PC/SC compatible CCID
Read and write all ISO7816-1/2/3/4-compatible Smartcards Automatic baud rate detection

Contactless Smartcard:
Protocol T=CL
Interface ISO 14443 A & B
● All Part-4 compliant cards
● German national ID (NPA)
● NXP product line (MIFARE, DESFire, SmartMX, etc.) ● For Part-4 noncompliant cards only UID is support (e.g. Infineon) ISO 15693 ● All ISO 15693-3 compliant Tags supporting optional commands ● iCODE 1, iCODE SLI
● LRI 64
● SLC Montalbano Technology
● Texas Instruments Tag-it
● Infineon (MY-D, MY-D light)

This addition adds the contact smartcard slot working.
Any idea how the contactless smartcard slot can be activated?
