### PR TITLE
commands: CmdPowerOn: Fix nlength return value in overflow case

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -294,8 +294,8 @@ again:
 	atr_len = dw2i(buffer, 1);	/* ATR length */
 	if (atr_len > *nlength - 10)
 		atr_len = *nlength - 10;
-	else
-		*nlength = atr_len;
+
+	*nlength = atr_len;
 
 	/* the buffer length should be 10 + MAX_ATR_SIZE */
 	memmove(buffer, buffer+10, atr_len);


### PR DESCRIPTION
CmdPowerOn is supposed to return ATR and its length in buffer/nlength.

A bounds check is performed in the code, and truncates atr_len to the length of the received data (minus 10 bytes for the header). However, in that case, nlength in not updated, leading to a returned ATR with trailing garbage.

This is an edge, error case, that should never happen, and was introduced while fixing a potentially more serious buffer overrun in 2020.

Fixes: a382095d8b19 ("CmdPowerOn: fix a potention overrun with bogus ATR")