### PR TITLE
ccid_usb: Simplify get_end_points/get_endpoints

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -135,8 +135,8 @@ static struct usbDevice_MultiSlot_Extension *Multi_CreateFirstSlot(int reader_in
 static struct usbDevice_MultiSlot_Extension *Multi_CreateNextSlot(int physical_reader_index);
 static void Multi_PollingTerminate(struct usbDevice_MultiSlot_Extension *msExt);
 
-static int get_end_points(struct libusb_config_descriptor *desc,
-	_usbDevice *usbdevice, int num);
+static int get_end_points(const struct libusb_interface *usb_interface,
+	_usbDevice *usbdevice);
 bool ccid_check_firmware(struct libusb_device_descriptor *desc);
 static unsigned int *get_data_rates(unsigned int reader_index,
 	struct libusb_config_descriptor *desc, int num);
@@ -772,7 +772,7 @@ again:
 #endif
 
 				/* Get Endpoints values*/
-				(void)get_end_points(config_desc, &usbDevice[reader_index], num);
+				(void)get_end_points(usb_interface, &usbDevice[reader_index]);
 
 				/* store device information */
 				usbDevice[reader_index].dev_handle = dev_handle;
@@ -1276,14 +1276,12 @@ const unsigned char *get_ccid_device_descriptor(const struct libusb_interface *u
  *					get_end_points
  *
  ****************************************************************************/
-static int get_end_points(struct libusb_config_descriptor *desc,
-	_usbDevice *usbdevice, int num)
+static int get_end_points(
+	const struct libusb_interface *usb_interface,
+	_usbDevice *usbdevice)
 {
 	int i;
 	int bEndpointAddress;
-	const struct libusb_interface *usb_interface;
-
-	usb_interface = get_ccid_usb_interface(desc, &num);
 
 	/*
 	 * 3 Endpoints maximum: Interrupt In, Bulk In, Bulk Out

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -139,7 +139,7 @@ static int get_end_points(const struct libusb_interface *usb_interface,
 	_usbDevice *usbdevice);
 bool ccid_check_firmware(struct libusb_device_descriptor *desc);
 static unsigned int *get_data_rates(unsigned int reader_index,
-	struct libusb_config_descriptor *desc, int num);
+	const unsigned char bNumDataRatesSupported);
 
 /* ne need to initialize to 0 since it is static */
 static _usbDevice usbDevice[CCID_DRIVER_MAX_READERS];
@@ -807,7 +807,7 @@ again:
 				usbDevice[reader_index].ccid.bCurrentSlotIndex = 0;
 				usbDevice[reader_index].ccid.readTimeout = DEFAULT_COM_READ_TIMEOUT;
 				if (device_descriptor[27])
-					usbDevice[reader_index].ccid.arrayOfSupportedDataRates = get_data_rates(reader_index, config_desc, num);
+					usbDevice[reader_index].ccid.arrayOfSupportedDataRates = get_data_rates(reader_index, device_descriptor[27]);
 				else
 				{
 					usbDevice[reader_index].ccid.arrayOfSupportedDataRates = NULL;
@@ -1421,14 +1421,12 @@ bool ccid_check_firmware(struct libusb_device_descriptor *desc)
  *
  ****************************************************************************/
 static unsigned int *get_data_rates(unsigned int reader_index,
-	struct libusb_config_descriptor *desc, int num)
+	const unsigned char bNumDataRatesSupported)
 {
 	int n, i, len;
 	unsigned char buffer[256*sizeof(int)];	/* maximum is 256 records */
 	unsigned int *uint_array;
-	int bNumDataRatesSupported;
 
-	bNumDataRatesSupported = get_ccid_device_descriptor(get_ccid_usb_interface(desc, &num))[27];
 	if (0 == bNumDataRatesSupported)
 		/* read up to the buffer size */
 		len = sizeof(buffer) / sizeof(int);


### PR DESCRIPTION
The caller already has the structures/data ready, so let's not make superfluous calls to `get_ccid_*` functions.