### PR TITLE
Avoid buffer overrun of we got too short response

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -594,6 +594,9 @@ RESPONSECODE SecurePINVerify(unsigned int reader_index,
 				ccid_descriptor->readTimeout = oldReadTimeout;
 			}
 
+			if (RxLength < 4) {
+				return IFD_COMMUNICATION_ERROR;
+			}
 			/* get only the T=1 data */
 			memmove(RxBuffer, RxBuffer+3, *RxLength -4);
 			*RxLength -= 4;	/* remove NAD, PCB, LEN and CRC */


### PR DESCRIPTION
This issue was pointed out by coverity that the memmove could be called with underflow value, if we get small answer from  `CCID_Receive()`. My proposal would be to add a sanity check to prevent that, but I am not that much familiar with all the code so I am open to other proposals or suggestions.

```
"Error: OVERRUN (CWE-119):
ccid-1.5.5/src/commands.c:594: write_constant: Write the value 2 into ""*RxLength"".
ccid-1.5.5/src/commands.c:603: overrun-buffer-arg: Calling ""memmove"" with ""RxBuffer"" and ""*RxLength - 4U"" is suspicious because of the very large index, 4294967294. The index may be due to a negative parameter being interpreted as unsigned. [Note: The source code implementation of the function has been overridden by a builtin model.]
#  601|   
#  602|   			/* get only the T=1 data */
#  603|-> 			memmove(RxBuffer, RxBuffer+3, *RxLength -4);
#  604|   			*RxLength -= 4;	/* remove NAD, PCB, LEN and CRC */
#  605|   		}"
```