### PR TITLE
Don't assume that all notifications are NotifySlotChange

### DIFF
--- a/src/ccid.h
+++ b/src/ccid.h
@@ -194,6 +194,32 @@ typedef struct
 #define PROTOCOL_ICCD_A	1	/* ICCD Version A */
 #define PROTOCOL_ICCD_B	2	/* ICCD Version B */
 
+/* Known CCID bMessageType values. */
+/* Command Pipe, Bulk-OUT Messages */
+#define PC_to_RDR_IccPowerOn 0x62
+#define PC_to_RDR_IccPowerOff 0x63
+#define PC_to_RDR_GetSlotStatus 0x65
+#define PC_to_RDR_XfrBlock 0x6F
+#define PC_to_RDR_GetParameters 0x6C
+#define PC_to_RDR_ResetParameters 0x6D
+#define PC_to_RDR_SetParameters 0x61
+#define PC_to_RDR_Escape 0x6B
+#define PC_to_RDR_IccClock 0x6E
+#define PC_to_RDR_T0APDU 0x6A
+#define PC_to_RDR_Secure 0x69
+#define PC_to_RDR_Mechanical 0x71
+#define PC_to_RDR_Abort 0x72
+#define PC_to_RDR_SetDataRateAndClockFrequency 0x73
+/* Response Pipe, Bulk-IN Messages */
+#define RDR_to_PC_DataBlock 0x80
+#define RDR_to_PC_SlotStatus 0x81
+#define RDR_to_PC_Parameters 0x82
+#define RDR_to_PC_Escape 0x83
+#define RDR_to_PC_DataRateAndClockFrequency 0x84
+/* Interrupt-IN Messages */
+#define RDR_to_PC_NotifySlotChange 0x50
+#define RDR_to_PC_HardwareError 0x51
+
 /* Product identification for special treatments */
 #define GEMPC433	0x08E64433
 #define GEMPCKEY	0x08E63438

--- a/src/ccid_serial.c
+++ b/src/ccid_serial.c
@@ -44,7 +44,6 @@
 #define SYNC 0x03
 #define CTRL_ACK 0x06
 #define CTRL_NAK 0x15
-#define RDR_to_PC_NotifySlotChange 0x50
 #define CARD_ABSENT 0x02
 #define CARD_PRESENT 0x03
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -211,7 +211,7 @@ check_again:
 
 again:
 	bSeq = (*ccid_descriptor->pbSeq)++;
-	cmd[0] = 0x62; /* IccPowerOn */
+	cmd[0] = PC_to_RDR_IccPowerOn;
 	cmd[1] = cmd[2] = cmd[3] = cmd[4] = 0;	/* dwLength */
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = bSeq;
@@ -311,7 +311,7 @@ RESPONSECODE SecurePINVerify(unsigned int reader_index,
 	uint32_t ulDataLength;
 
 	pvs = (PIN_VERIFY_STRUCTURE *)TxBuffer;
-	cmd[0] = 0x69;	/* Secure */
+	cmd[0] = PC_to_RDR_Secure;
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = (*ccid_descriptor->pbSeq)++;
 	cmd[7] = 0;		/* bBWI */
@@ -663,7 +663,7 @@ RESPONSECODE SecurePINModify(unsigned int reader_index,
 	uint32_t ulDataLength;
 
 	pms = (PIN_MODIFY_STRUCTURE *)TxBuffer;
-	cmd[0] = 0x69;	/* Secure */
+	cmd[0] = PC_to_RDR_Secure;
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = (*ccid_descriptor->pbSeq)++;
 	cmd[7] = 0;		/* bBWI */
@@ -973,7 +973,7 @@ again:
 	}
 
 	bSeq = (*ccid_descriptor->pbSeq)++;
-	cmd_in[0] = 0x6B; /* PC_to_RDR_Escape */
+	cmd_in[0] = PC_to_RDR_Escape;
 	i2dw(length_in - 10, cmd_in+1);	/* dwLength */
 	cmd_in[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd_in[6] = bSeq;
@@ -1122,7 +1122,7 @@ RESPONSECODE CmdPowerOff(unsigned int reader_index)
 #endif
 
 	bSeq = (*ccid_descriptor->pbSeq)++;
-	cmd[0] = 0x63; /* IccPowerOff */
+	cmd[0] = PC_to_RDR_IccPowerOff;
 	cmd[1] = cmd[2] = cmd[3] = cmd[4] = 0;	/* dwLength */
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = bSeq;
@@ -1248,7 +1248,7 @@ again_status:
 #endif
 
 	bSeq = (*ccid_descriptor->pbSeq)++;
-	cmd[0] = 0x65; /* GetSlotStatus */
+	cmd[0] = PC_to_RDR_GetSlotStatus;
 	cmd[1] = cmd[2] = cmd[3] = cmd[4] = 0;	/* dwLength */
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = bSeq;
@@ -1391,7 +1391,7 @@ RESPONSECODE CCID_Transmit(unsigned int reader_index, unsigned int tx_length,
 	}
 #endif
 
-	cmd[0] = 0x6F; /* XfrBlock */
+	cmd[0] = PC_to_RDR_XfrBlock;
 	i2dw(tx_length, cmd+1);	/* APDU length */
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = (*ccid_descriptor->pbSeq)++;
@@ -2317,7 +2317,7 @@ RESPONSECODE SetParameters(unsigned int reader_index, char protocol,
 	DEBUG_COMM2("length: %d bytes", length);
 
 	bSeq = (*ccid_descriptor->pbSeq)++;
-	cmd[0] = 0x61; /* SetParameters */
+	cmd[0] = PC_to_RDR_SetParameters;
 	i2dw(length, cmd+1);	/* APDU length */
 	cmd[5] = ccid_descriptor->bCurrentSlotIndex;	/* slot number */
 	cmd[6] = bSeq;


### PR DESCRIPTION
CCID defines another type of message type on the interrupt pipe,
HardwareError, and others may also be conceivably sent. So check the
message type instead of assuming it's a NotifySlotChange.

While at it, I added debug logging of HardwareError, it might be useful
for someone.

Note 1: I recommend viewing the second commit ignoring whitespace, it makes the diff clearer.

Note 2: I don't have a multi-slot reader, so I wasn't able to test the `Multi_` code paths.