### PR TITLE
Avoid LIBUSB_ERROR_OVERFLOW errors

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -88,7 +88,7 @@ RESPONSECODE CmdPowerOn(unsigned int reader_index, unsigned int * nlength,
 	unsigned char buffer[], int voltage)
 {
 	unsigned char cmd[10];
-	unsigned char resp[10 + MAX_ATR_SIZE];
+	unsigned char resp[ROUND_UP_BUF(10 + MAX_ATR_SIZE)];
 	int bSeq;
 	status_t res;
 	int count = 1;
@@ -964,7 +964,7 @@ again:
 		goto end;
 	}
 
-	length_out = 10 + *RxLength;
+	length_out = ROUND_UP_BUF(10 + *RxLength);
 	if (NULL == (cmd_out = malloc(length_out)))
 	{
 		free(cmd_in);
@@ -995,7 +995,7 @@ again:
 	}
 
 time_request:
-	length_out = 10 + *RxLength;
+	length_out = ROUND_UP_BUF(10 + *RxLength);
 	res = ReadPort(reader_index, &length_out, cmd_out, bSeq);
 
 	/* replay the command if NAK
@@ -1067,7 +1067,7 @@ end:
  ****************************************************************************/
 RESPONSECODE CmdPowerOff(unsigned int reader_index)
 {
-	unsigned char cmd[10];
+	unsigned char cmd[ROUND_UP_BUF(10)];
 	int bSeq;
 	status_t res;
 	unsigned int length;
@@ -1128,7 +1128,7 @@ RESPONSECODE CmdPowerOff(unsigned int reader_index)
 	cmd[6] = bSeq;
 	cmd[7] = cmd[8] = cmd[9] = 0; /* RFU */
 
-	res = WritePort(reader_index, sizeof(cmd), cmd);
+	res = WritePort(reader_index, 10, cmd);
 	CHECK_STATUS(res)
 
 	length = sizeof(cmd);
@@ -1418,7 +1418,7 @@ RESPONSECODE CCID_Transmit(unsigned int reader_index, unsigned int tx_length,
 RESPONSECODE CCID_Receive(unsigned int reader_index, unsigned int *rx_length,
 	unsigned char rx_buffer[], unsigned char *chain_parameter)
 {
-	unsigned char cmd[10+CMD_BUF_SIZE];	/* CCID + APDU buffer */
+	unsigned char cmd[ROUND_UP_BUF(10+CMD_BUF_SIZE)];	/* CCID + APDU buffer */
 	unsigned int length;
 	RESPONSECODE return_value = IFD_SUCCESS;
 	status_t ret;
@@ -2310,7 +2310,7 @@ static RESPONSECODE CmdXfrBlockTPDU_T1(unsigned int reader_index,
 RESPONSECODE SetParameters(unsigned int reader_index, char protocol,
 	unsigned int length, unsigned char buffer[])
 {
-	unsigned char cmd[10+length+2];	/* CCID + Protocol Data Structure */
+	unsigned char cmd[ROUND_UP_BUF(10+length+2)];	/* CCID + Protocol Data Structure */
 	int bSeq;
 	_ccid_descriptor *ccid_descriptor = get_ccid_descriptor(reader_index);
 	status_t res;

--- a/src/commands.h
+++ b/src/commands.h
@@ -17,7 +17,17 @@
 	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#define SIZE_GET_SLOT_STATUS 10
+/* Round `num` up to be a multiple of `multiple`. */
+#define ROUND_UP(num, multiple) (((num) + (multiple) - 1) / (multiple) * (multiple))
+
+/* Round up buffer sizes to avoid LIBUSB_TRANSFER_OVERFLOW errors from devices
+ * which erroneously send larger responses than expected. 1024 is taken as a
+ * safe maximum wMaxPacketSize for CCID devices. See:
+ * https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html */
+#define ROUND_UP_BUF(needed) ROUND_UP(needed, 1024)
+
+/* Needed buffer size for CmdGetSlotStatus. */
+#define SIZE_GET_SLOT_STATUS ROUND_UP_BUF(10)
 #define STATUS_OFFSET 7
 #define ERROR_OFFSET 8
 #define CHAIN_PARAMETER_OFFSET 9


### PR DESCRIPTION
I am trying to get the CCID driver to work with a bit finicky industrial device. Occasionally the communication with the device fails with error LIBUSB_TRANSFER_OVERFLOW, and then things stop working. The reason for this error is described here:
https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html

The errors look like this:

```
pcscd 99999999 src/ccid_usb.c:1082:ReadUSB() read failed (1/14): LIBUSB_ERROR_OVERFLOW
pcscd 00000038 src/ifdhandler.c:1244:IFDHPowerICC() PowerDown failed
pcscd 63039068 src/ccid_usb.c:1082:ReadUSB() read failed (1/14): LIBUSB_ERROR_TIMEOUT
pcscd 00000022 src/ifdhandler.c:1296:IFDHPowerICC() PowerUp failed
pcscd 00000005 winscard.c:333:SCardConnect() Error powering up card: rv=SCARD_E_NOT_TRANSACTED
pcscd 00000004 prothandler.c:86:PHSetProtocol() Protocol T=1 requested but unsupported by the card
```

Reader:
idVendor: 0x0483
iManufacturer: TITENG
idProduct: 0x3258
iProduct: TIT-RFREADR-CL

As described in the libusb doc, I was able to resolve the problem by tweaking the buffer sizes that CCID is passing to ReadPort (AKA ReadUSB) in the commands.c file. In principle, the needed tweak is to make the buffer sizes a multiple of the endpoint's wMaxPacketSize. This value can be queried from libusb. In all CCID readers I have, the value is always 64 bytes, however in the latest USB version (3.2, very unlikely to actually be used by CCID readers) it can go up to 1024 bytes if I understand correctly. So we can avoid dealing with wMaxPacketSize and just assume 1024.

Fixes https://github.com/LudovicRousseau/CCID/issues/161