### PR TITLE
multi slots: fix potential race in interrupt handling

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1646,11 +1646,10 @@ int InterruptRead(int reader_index, int timeout /* in ms */)
 	if (NULL == transfer)
 		return LIBUSB_ERROR_NO_MEM;
 
-	libusb_fill_bulk_transfer(transfer,
+	libusb_fill_interrupt_transfer(transfer,
 		usbDevice[reader_index].dev_handle,
 		usbDevice[reader_index].interrupt, buffer, sizeof(buffer),
 		bulk_transfer_cb, &completed, timeout);
-	transfer->type = LIBUSB_TRANSFER_TYPE_INTERRUPT;
 
 	ret = libusb_submit_transfer(transfer);
 	if (ret < 0) {
@@ -1801,13 +1800,11 @@ static void *Multi_PollingProc(void *p_ext)
 			usbDevice[msExt->reader_index].device_address);
 
 		completed = 0;
-		libusb_fill_bulk_transfer(transfer,
+		libusb_fill_interrupt_transfer(transfer,
 			usbDevice[msExt->reader_index].dev_handle,
 			usbDevice[msExt->reader_index].interrupt,
 			buffer, CCID_INTERRUPT_SIZE,
 			bulk_transfer_cb, &completed, 0); /* No timeout ! */
-
-		transfer->type = LIBUSB_TRANSFER_TYPE_INTERRUPT;
 
 		rv = libusb_submit_transfer(transfer);
 		if (rv)

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1800,6 +1800,7 @@ static void *Multi_PollingProc(void *p_ext)
 			usbDevice[msExt->reader_index].bus_number,
 			usbDevice[msExt->reader_index].device_address);
 
+		completed = 0;
 		libusb_fill_bulk_transfer(transfer,
 			usbDevice[msExt->reader_index].dev_handle,
 			usbDevice[msExt->reader_index].interrupt,
@@ -1820,7 +1821,6 @@ static void *Multi_PollingProc(void *p_ext)
 		usbDevice[msExt->reader_index].polling_transfer = transfer;
 		pthread_mutex_unlock(&usbDevice[msExt->reader_index].polling_transfer_mutex);
 
-		completed = 0;
 		while (!completed && !msExt->terminated)
 		{
 			rv = libusb_handle_events_completed(ctx, &completed);


### PR DESCRIPTION
Initialize completed before calling libusb_submit_transfer. Otherwise it is possible that the callback fires in another thread first, and the completed=1 assignment gets lost.

Also use volatile int for the completed flag to hint that it can change from another thread.

Potentially fixes #166