### PR TITLE
Return IFD_SUCCESS from InterruptRead if it was cancelled

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1721,6 +1721,7 @@ int InterruptRead(int reader_index, int timeout /* in ms */)
 			break;
 
 		case LIBUSB_TRANSFER_TIMED_OUT:
+		case LIBUSB_TRANSFER_CANCELLED:
 			break;
 
 		default:


### PR DESCRIPTION
PCSC uses the InterruptRead() return value to determine if it should throttle the polling. This makes sense if communication error happened.

InterruptStop() is used to explicitly re-request immediate handling of changed status. So treat the cancelled state as success return value to avoid unnecessary delay.