### PR TITLE
Modify OpenSerialByName to use ReaderID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,3 @@ src/towitoko/.dirstamp
 src/towitoko/.libs/
 stamp-h1
 tags
-.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ src/towitoko/.dirstamp
 src/towitoko/.libs/
 stamp-h1
 tags
+.idea/workspace.xml

--- a/src/ccid_serial.c
+++ b/src/ccid_serial.c
@@ -789,7 +789,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 	current_termios.c_lflag = 0;
 
 	readerID = serialDevice[reader].ccid.readerID;
-	if (readerID == GEMCORESIMPRO2)
+	if (GEMCORESIMPRO2 == readerID)
 	{
 		unsigned char pcbuffer[SIZE_GET_SLOT_STATUS];
 		unsigned int old_timeout;
@@ -861,7 +861,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 		unsigned char rx_buffer[50];
 		unsigned int rx_length = sizeof(rx_buffer);
 
-		if (readerID == SEC1210)
+		if (SEC1210 == readerID)
 			tx_buffer[0] = 0x06; // unknown but supported command
 		else
 			tx_buffer[0] = 0x02; // get reader firmware
@@ -882,7 +882,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 	/* perform a command to configure GemPC Twin reader card movement
 	 * notification to synchronous mode: the card movement is notified _after_
 	 * the host command and _before_ the reader answer */
-	if (readerID != SEC1210)
+	if (SEC1210 != readerID)
 	{
 		unsigned char tx_buffer[] = { 0x01, 0x01, 0x01};
 		unsigned char rx_buffer[50];

--- a/src/ccid_serial.c
+++ b/src/ccid_serial.c
@@ -702,6 +702,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 	char reader_name[255] = "GemPCTwin";
 	char *p;
 	status_t ret;
+	int readerID;
 
 	DEBUG_COMM3("Reader index: %X, Device: %s", reader_index, dev_name);
 
@@ -787,7 +788,8 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 	 * will echo characters for you.  Don't generate signals. */
 	current_termios.c_lflag = 0;
 
-	if (0 == strcasecmp(reader_name,"GemCoreSIMPro2"))
+	readerID = serialDevice[reader].ccid.readerID;
+	if (readerID == GEMCORESIMPRO2)
 	{
 		unsigned char pcbuffer[SIZE_GET_SLOT_STATUS];
 		unsigned int old_timeout;
@@ -859,7 +861,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 		unsigned char rx_buffer[50];
 		unsigned int rx_length = sizeof(rx_buffer);
 
-		if (0 == strcasecmp(reader_name,"SEC1210"))
+		if (readerID == SEC1210)
 			tx_buffer[0] = 0x06; // unknown but supported command
 		else
 			tx_buffer[0] = 0x02; // get reader firmware
@@ -880,7 +882,7 @@ status_t OpenSerialByName(unsigned int reader_index, char *dev_name)
 	/* perform a command to configure GemPC Twin reader card movement
 	 * notification to synchronous mode: the card movement is notified _after_
 	 * the host command and _before_ the reader answer */
-	if (0 != strcasecmp(reader_name,"SEC1210"))
+	if (readerID != SEC1210)
 	{
 		unsigned char tx_buffer[] = { 0x01, 0x01, 0x01};
 		unsigned char rx_buffer[50];


### PR DESCRIPTION
Modify OpenSerialByName to use ReaderID as opposed to doing multiple string comparisons on the reader name.

Replaces https://github.com/LudovicRousseau/CCID/pull/167

Precursor for adding SEC1210URT support. (That will come later next and is here: https://github.com/3rdIteration/CCID/tree/Add_SEC1210URT)
