### PR TITLE
Signal event when SEC1210 readers are added out of order

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -896,6 +896,11 @@ again:
 						usbDevice[reader_index].ccid.sec1210_other_interface -> sec1210_other_interface = &usbDevice[reader_index].ccid;
 						/* share the cond struct */
 						usbDevice[reader_index].ccid.sec1210_shared = usbDevice[other_interface_index].ccid.sec1210_shared;
+						/* signal change if first interface comes after second */
+						if (interface == 0) {
+							DEBUG_INFO1("SEC1210: First interface came second, signaling");
+							pthread_cond_signal(&usbDevice[reader_index].ccid.sec1210_shared->sec1210_cond);
+						}
 					}
 					else
 					{


### PR DESCRIPTION
When the reader interfaces of the SEC1210 reader are detected out of order (i.e., interface 2 is added before interface 1), sometimes the card presence of the second one is wrong. This is because it defaults to `IFD_ICC_NOT_PRESENT` if the first interface is missing.

This notifies a change event to the second interface if the first interface is detected first in order to update the presence to the correct value.