### PR TITLE
Update rules file to comply with systemd documentation

### DIFF
--- a/src/92_pcscd_ccid.rules
+++ b/src/92_pcscd_ccid.rules
@@ -4,7 +4,7 @@
 #SUBSYSTEMS=="pcmcia", DRIVERS=="serial_cs", ACTION=="add", ATTRS{prod_id1}=="Gemplus", ATTRS{prod_id2}=="SerialPort", ATTRS{prod_id3}=="GemPC Card", RUN+="/usr/sbin/pcscd --hotplug" 
 
 # If not adding the device, go away
-ACTION!="add", GOTO="pcscd_ccid_rules_end"
+ACTION=="remove", GOTO="pcscd_ccid_rules_end"
 SUBSYSTEM!="usb", GOTO="pcscd_ccid_rules_end"
 ENV{DEVTYPE}!="usb_device", GOTO="pcscd_ccid_rules_end"
 


### PR DESCRIPTION
systemd version 247 included this notice [*1]:

     All rule files that currently use a header guard similar to
     ACTION!="add|change",GOTO="xyz_end" should be updated to use
     ACTION=="remove",GOTO="xyz_end" instead,

This commit makes that change and, by doing so, prevents a permissions issue where the device node becomes unaccessible to non-root users (more details in [*2]).

[*1] https://github.com/systemd/systemd/blob/bf6e5c574b08e934cdfab18317c51987b001db58/NEWS#L51
[*2] https://github.com/systemd/systemd/issues/40900