### PR TITLE
ccid_usb: Avoid LIBUSB_ERROR_OVERFLOW via temporary aligned buffer in ReadUSB

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -45,6 +45,9 @@
 /* Round up `num` to a multiple of `multiple` (must be > 0). */
 #define ROUND_UP(num, multiple) (((num) + (multiple) - 1) / (multiple) * (multiple))
 
+/* Offset of the bSeq field in the CCID RDR_to_PC header. */
+#define BSEQ_OFFSET 6
+
 
 /* write timeout
  * we don't have to wait a long time since the card was doing nothing */
@@ -1162,6 +1165,27 @@ read_again:
 			return STATUS_UNSUCCESSFUL;
 		}
 
+		DEBUG_XXD(debug_header, tmp_buffer, actual_length);
+
+		/* bSeq mismatch BEFORE the size check, so stale frames (left
+		 * over from previous commands) are discarded and we retry
+		 * instead of being rejected outright. */
+		if ((actual_length >= BSEQ_OFFSET + 1)
+			&& (bSeq != -1)
+			&& (tmp_buffer[BSEQ_OFFSET] != bSeq))
+		{
+			duplicate_frame++;
+			if (duplicate_frame > 10)
+			{
+				DEBUG_CRITICAL("Too many duplicate frame detected");
+				free(tmp_buffer);
+				return STATUS_UNSUCCESSFUL;
+			}
+			DEBUG_INFO1("Invalid frame detected");
+			free(tmp_buffer);
+			goto read_again;
+		}
+
 		if ((unsigned int)actual_length > *length)
 		{
 			DEBUG_CRITICAL3("Received %d bytes but caller buffer is only %u",
@@ -1176,10 +1200,10 @@ read_again:
 		*length = actual_length;
 	}
 
-	DEBUG_XXD(debug_header, buffer, *length);
-
-#define BSEQ_OFFSET 6
-	if ((*length >= BSEQ_OFFSET +1)
+	/* multislot_extension path: legacy bSeq check on the caller buffer.
+	 * For the simple (libusb_bulk_transfer) path this is already done
+	 * above on tmp_buffer, so the check here is a no-op. */
+	if ((*length >= BSEQ_OFFSET + 1)
 		&& (bSeq != -1)
 		&& (buffer[BSEQ_OFFSET] != bSeq))
 	{

--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -42,6 +42,9 @@
 #include "ccid_ifdhandler.h"
 #include "sys_generic.h"
 
+/* Round up `num` to a multiple of `multiple` (must be > 0). */
+#define ROUND_UP(num, multiple) (((num) + (multiple) - 1) / (multiple) * (multiple))
+
 
 /* write timeout
  * we don't have to wait a long time since the card was doing nothing */
@@ -1121,9 +1124,28 @@ read_again:
 	}
 	else
 	{
+		/* Issue #161: some CCID devices send USB packets that cross the
+		 * caller-buffer boundary, triggering LIBUSB_ERROR_OVERFLOW which
+		 * leaves the endpoint in a stuck state. Workaround per
+		 * https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html
+		 * is to receive into a temporary buffer whose size is a multiple
+		 * of the endpoint's wMaxPacketSize. 1024 covers every CCID
+		 * endpoint size up to USB 3.2. The payload is then memcpy()'d
+		 * back into the caller's buffer after a sanity check. */
+		unsigned int rounded_length = ROUND_UP(*length, 1024);
+		unsigned char *tmp_buffer = malloc(rounded_length);
+
+		if (NULL == tmp_buffer)
+		{
+			*length = 0;
+			DEBUG_CRITICAL2("malloc(%u) failed", rounded_length);
+			return STATUS_UNSUCCESSFUL;
+		}
+
 		rv = libusb_bulk_transfer(usbDevice[reader_index].dev_handle,
-			usbDevice[reader_index].bulk_in, buffer, *length,
-			&actual_length, usbDevice[reader_index].ccid.readTimeout);
+			usbDevice[reader_index].bulk_in, tmp_buffer,
+			rounded_length, &actual_length,
+			usbDevice[reader_index].ccid.readTimeout);
 
 		if (rv < 0)
 		{
@@ -1132,6 +1154,7 @@ read_again:
 				usbDevice[reader_index].bus_number,
 				usbDevice[reader_index].device_address,
 				libusb_error_name(rv));
+			free(tmp_buffer);
 
 			if (LIBUSB_ERROR_NO_DEVICE == rv)
 				return STATUS_NO_SUCH_DEVICE;
@@ -1139,6 +1162,17 @@ read_again:
 			return STATUS_UNSUCCESSFUL;
 		}
 
+		if ((unsigned int)actual_length > *length)
+		{
+			DEBUG_CRITICAL3("Received %d bytes but caller buffer is only %u",
+				actual_length, *length);
+			free(tmp_buffer);
+			*length = 0;
+			return STATUS_UNSUCCESSFUL;
+		}
+
+		memcpy(buffer, tmp_buffer, actual_length);
+		free(tmp_buffer);
 		*length = actual_length;
 	}
 


### PR DESCRIPTION
… ReadUSB

Some CCID devices send USB packets that cross the caller-buffer boundary during libusb_bulk_transfer(), triggering LIBUSB_ERROR_OVERFLOW. After this error the endpoint stays in a stuck state and pcscd stops being able to talk to the reader. Root cause is described in the libusb documentation:

    https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html

Bluetech (PR #164) proposed solving this by rounding up every caller buffer in commands.c to a multiple of 1024 bytes via a ROUND_UP_BUF() macro. That PR was closed as wontfix, but during the review discussion the maintainer suggested:

    "It would be easier to just modify ReadUSB() to use a temporary big
     buffer. Then no need to touch anything in commands.c"

This patch implements that suggestion. The simple libusb_bulk_transfer() branch of ReadUSB() now allocates a temporary buffer rounded up to a multiple of 1024 bytes (the maximum wMaxPacketSize for any CCID endpoint across USB 1.x/2.0/3.x). The transfer is performed into that buffer, and the data is then memcpy()'d back into the caller's buffer after a sanity check that the device did not send more data than the caller expected.

Tradeoffs vs PR #164:
- Pro: one function modified instead of seven call sites in commands.c.
- Pro: no public macro added; no risk of impedance mismatch between call sites that adopt the macro and those that don't.
- Pro: caller-buffer overflows that previously only manifested as LIBUSB_ERROR_OVERFLOW now also trip an explicit "actual_length greater than caller buffer" guard, which is a strictly safer behaviour for downstream callers.
- Con: one malloc/free per ReadUSB call. The cost is negligible compared to the USB round-trip latency (microseconds vs milliseconds), and is acceptable for the safety guarantee gained.

The multislot_extension branch of ReadUSB and the libusb_bulk_transfer calls in Multi_PollingProc / Multi_InterruptRead are NOT touched by this patch — they have a different code path (separate polling thread + queue of frames) and are out of scope for this fix.

Tested on:
  - Ubuntu 26.04, libccid built from current master + this patch
  - Neowave WinkeoSIM (USB ID 1e0d:0013), Oberthur v7 PKI applet (ChamberSign Eiducio certificate). Before the patch, the journalctl output contained recurring "LIBUSB_ERROR_OVERFLOW" and "LIBUSB_ERROR_TIMEOUT" lines on every PowerOn attempt; after the patch those errors are entirely gone.

Note that on the WinkeoSIM device there is a separate, unrelated issue ("Card not transacted: 612" at the IFD layer with bNumDataRatesSupported reported as 0 in the CCID class descriptor) which is not addressed by this patch — it remains to be investigated as a distinct issue, possibly in CmdPowerOn handling or in the middleware. The patch is still a strict improvement: it removes one real bug from the USB layer, even if a second hardware-quirk bug remains for that particular device.

Refs: https://github.com/LudovicRousseau/CCID/issues/161
Refs: https://github.com/LudovicRousseau/CCID/pull/164

Refs #161
Refs #164

Credit-where-due: the analysis of the LIBUSB_ERROR_OVERFLOW root cause and the initial workaround idea came from Ran Benita (bluetech) in PR #164. This patch only re-implements the maintainer's preferred location for the fix.