### PR TITLE
fix(ccid_usb): correctly report IFD_NO_SUCH_DEVICE in InterruptRead

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1660,6 +1660,8 @@ int InterruptRead(CcidDesc *ccid_reader, int timeout /* in ms */)
 		libusb_free_transfer(transfer);
 		DEBUG_CRITICAL2("libusb_submit_transfer failed: %s",
 			libusb_error_name(ret));
+		if (LIBUSB_ERROR_NO_DEVICE == ret)
+			return IFD_NO_SUCH_DEVICE;
 		return IFD_COMMUNICATION_ERROR;
 	}
 
@@ -1726,6 +1728,10 @@ int InterruptRead(CcidDesc *ccid_reader, int timeout /* in ms */)
 
 		case LIBUSB_TRANSFER_TIMED_OUT:
 		case LIBUSB_TRANSFER_CANCELLED:
+			break;
+
+		case LIBUSB_TRANSFER_NO_DEVICE:
+			return_value = IFD_NO_SUCH_DEVICE;
 			break;
 
 		default:


### PR DESCRIPTION
After a suspend to ram and a resume, libusb device handles can be stale, causing libusb_free_transfer to err with LIBUSB_ERROR_NO_DEVICE. Reporting IFD_NO_SUCH_DEVICE likewise tells dependents that the device is stale.

Also correctly reports IFD_NO_SUCH_DEVICE on a LIBUSB_TRANSFER_NO_DEVICE, which is more descriptive than a generic IFD_COMMUNICATION_ERROR.

This is patch one of a two-patch series targeting both the CCID and PCSC repos.